### PR TITLE
Remove static factories in JsonReader and JsonWriter

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,32 +79,32 @@ foreach (JsonValue value in numbers)
 
 ```csharp
 // Reading from string
-var reader = JsonReader.Create(new StringReader(jsonString));
+var reader = new JsonReader(new StringReader(jsonString));
 JsonValue value = reader.Read();
 JsonObject obj = reader.ReadObject();
 JsonArray arr = reader.ReadArray();
 
 // Reading from stream
 using var fileStream = File.OpenRead("data.json");
-var streamReader = JsonReader.Create(fileStream);
+var streamReader = new JsonReader(new StreamReader(fileStream));
 var data = streamReader.ReadObject();
 
 // Writing to string
-var writer = JsonWriter.Create(new StringWriter());
+var writer = new JsonWriter(new StringWriter());
 writer.Write(person);
 string json = stringWriter.ToString();
 
 // Writing with formatting
 var options = new JsonWriterOptions { IndentOutput = true };
-var prettyWriter = JsonWriter.Create(new StringWriter(), options);
+var prettyWriter = new JsonWriter(new StringWriter(), options);
 prettyWriter.WriteObject(person);
 
 // Writing Unicode characters without escaping (Cyrillic, Chinese, etc.)
-var unicodeWriter = JsonWriter.Create(new StringWriter(), JsonWriterOptions.UnicodeUnescaped);
+var unicodeWriter = new JsonWriter(new StringWriter(), JsonWriterOptions.UnicodeUnescaped);
 unicodeWriter.Write(new JsonString("Привет мир")); // Writes: "Привет мир" (not "\u041F...")
 
 // Pretty print with Unicode
-var prettyUnicode = JsonWriter.Create(new StringWriter(), JsonWriterOptions.PrettyPrintUnicodeUnescaped);
+var prettyUnicode = new JsonWriter(new StringWriter(), JsonWriterOptions.PrettyPrintUnicodeUnescaped);
 ```
 
 ### JSON Pointer (RFC 6901)

--- a/src/SergeiM.Json.Tests/GlobalUsings.cs
+++ b/src/SergeiM.Json.Tests/GlobalUsings.cs
@@ -2,6 +2,5 @@
 // SPDX-License-Identifier: MIT
 
 global using Microsoft.VisualStudio.TestTools.UnitTesting;
-global using SergeiM.Json;
 global using SergeiM.Json.Builders;
 global using SergeiM.Json.IO;

--- a/src/SergeiM.Json.Tests/JsonReaderTests/BasicReadTests.cs
+++ b/src/SergeiM.Json.Tests/JsonReaderTests/BasicReadTests.cs
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) [2025-2026] [Sergei Mukhin]
 // SPDX-License-Identifier: MIT
 
-using SergeiM.Json.IO;
-
 namespace SergeiM.Json.Tests.JsonReaderTests;
 
 [TestClass]
@@ -11,7 +9,7 @@ public class BasicReadTests
     [TestMethod]
     public void Read_SimpleObject_ReturnsJsonObject()
     {
-        using var reader = JsonReader.Create(new StringReader("{\"name\":\"Alice\",\"age\":30}"));
+        using var reader = new JsonReader(new StringReader("{\"name\":\"Alice\",\"age\":30}"));
         var value = reader.Read();
         Assert.IsNotNull(value);
         Assert.AreEqual(JsonValueType.Object, value.ValueType);
@@ -23,7 +21,7 @@ public class BasicReadTests
     [TestMethod]
     public void Read_SimpleArray_ReturnsJsonArray()
     {
-        using var reader = JsonReader.Create(new StringReader("[1,2,3]"));
+        using var reader = new JsonReader(new StringReader("[1,2,3]"));
         var value = reader.Read();
         Assert.IsNotNull(value);
         Assert.AreEqual(JsonValueType.Array, value.ValueType);
@@ -37,7 +35,7 @@ public class BasicReadTests
     [TestMethod]
     public void Read_String_ReturnsJsonString()
     {
-        using var reader = JsonReader.Create(new StringReader("\"hello\""));
+        using var reader = new JsonReader(new StringReader("\"hello\""));
         var value = reader.Read();
         Assert.IsNotNull(value);
         Assert.AreEqual(JsonValueType.String, value.ValueType);
@@ -47,7 +45,7 @@ public class BasicReadTests
     [TestMethod]
     public void Read_Number_ReturnsJsonNumber()
     {
-        using var reader = JsonReader.Create(new StringReader("42"));
+        using var reader = new JsonReader(new StringReader("42"));
         var value = reader.Read();
         Assert.IsNotNull(value);
         Assert.AreEqual(JsonValueType.Number, value.ValueType);
@@ -57,7 +55,7 @@ public class BasicReadTests
     [TestMethod]
     public void Read_Boolean_ReturnsJsonBoolean()
     {
-        using var reader = JsonReader.Create(new StringReader("true"));
+        using var reader = new JsonReader(new StringReader("true"));
         var value = reader.Read();
         Assert.IsNotNull(value);
         Assert.AreEqual(JsonValueType.Boolean, value.ValueType);
@@ -67,7 +65,7 @@ public class BasicReadTests
     [TestMethod]
     public void Read_Null_ReturnsJsonNull()
     {
-        using var reader = JsonReader.Create(new StringReader("null"));
+        using var reader = new JsonReader(new StringReader("null"));
         var value = reader.Read();
         Assert.IsNotNull(value);
         Assert.AreEqual(JsonValueType.Null, value.ValueType);

--- a/src/SergeiM.Json.Tests/JsonReaderTests/ComplexStructureTests.cs
+++ b/src/SergeiM.Json.Tests/JsonReaderTests/ComplexStructureTests.cs
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) [2025-2026] [Sergei Mukhin]
 // SPDX-License-Identifier: MIT
 
-using SergeiM.Json.IO;
-
 namespace SergeiM.Json.Tests.JsonReaderTests;
 
 [TestClass]
@@ -22,7 +20,7 @@ public class ComplexStructureTests
                     ""phones"": [""555-1234"", ""555-5678""]
                 }
             }";
-        using var reader = JsonReader.Create(new StringReader(json));
+        using var reader = new JsonReader(new StringReader(json));
         var person = reader.ReadObject().GetJsonObject("person");
         Assert.IsNotNull(person);
         Assert.AreEqual("John", person!.GetString("name"));
@@ -45,7 +43,7 @@ public class ComplexStructureTests
                 {""id"": 1, ""name"": ""Alice""},
                 {""id"": 2, ""name"": ""Bob""}
             ]";
-        using var reader = JsonReader.Create(new StringReader(json));
+        using var reader = new JsonReader(new StringReader(json));
         var arr = reader.ReadArray();
         Assert.AreEqual(2, arr.Count);
         var first = arr.GetJsonObject(0);

--- a/src/SergeiM.Json.Tests/JsonReaderTests/ErrorHandlingTests.cs
+++ b/src/SergeiM.Json.Tests/JsonReaderTests/ErrorHandlingTests.cs
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) [2025-2026] [Sergei Mukhin]
 // SPDX-License-Identifier: MIT
 
-using SergeiM.Json.IO;
-
 namespace SergeiM.Json.Tests.JsonReaderTests;
 
 [TestClass]
@@ -12,7 +10,7 @@ public class ErrorHandlingTests
     [ExpectedException(typeof(JsonException))]
     public void Read_InvalidJson_ThrowsJsonException()
     {
-        using var reader = JsonReader.Create(new StringReader("{invalid}"));
+        using var reader = new JsonReader(new StringReader("{invalid}"));
         reader.Read();
     }
 
@@ -20,7 +18,7 @@ public class ErrorHandlingTests
     [ExpectedException(typeof(JsonException))]
     public void Read_UnterminatedString_ThrowsJsonException()
     {
-        using var reader = JsonReader.Create(new StringReader("\"unterminated"));
+        using var reader = new JsonReader(new StringReader("\"unterminated"));
         reader.Read();
     }
 
@@ -28,7 +26,7 @@ public class ErrorHandlingTests
     [ExpectedException(typeof(JsonException))]
     public void Read_UnterminatedArray_ThrowsJsonException()
     {
-        using var reader = JsonReader.Create(new StringReader("[1,2,3"));
+        using var reader = new JsonReader(new StringReader("[1,2,3"));
         reader.Read();
     }
 
@@ -36,7 +34,7 @@ public class ErrorHandlingTests
     [ExpectedException(typeof(JsonException))]
     public void Read_UnterminatedObject_ThrowsJsonException()
     {
-        using var reader = JsonReader.Create(new StringReader("{\"key\":\"value\""));
+        using var reader = new JsonReader(new StringReader("{\"key\":\"value\""));
         reader.Read();
     }
 }

--- a/src/SergeiM.Json.Tests/JsonReaderTests/OptionsTests.cs
+++ b/src/SergeiM.Json.Tests/JsonReaderTests/OptionsTests.cs
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) [2025-2026] [Sergei Mukhin]
 // SPDX-License-Identifier: MIT
 
-using SergeiM.Json.IO;
-
 namespace SergeiM.Json.Tests.JsonReaderTests;
 
 [TestClass]
@@ -11,7 +9,7 @@ public class OptionsTests
     [TestMethod]
     public void Read_WithComments_AllowCommentsOption()
     {
-        using var reader = JsonReader.Create(
+        using var reader = new JsonReader(
             new StringReader("{\"value\":10/* comment */}"),
             new JsonReaderOptions { AllowComments = true });
         Assert.AreEqual(10, reader.ReadObject().GetInt("value"));
@@ -21,14 +19,14 @@ public class OptionsTests
     [ExpectedException(typeof(JsonException))]
     public void Read_WithComments_DefaultOptions_ThrowsException()
     {
-        using var reader = JsonReader.Create(new StringReader("{\"value\":10/* comment */}"));
+        using var reader = new JsonReader(new StringReader("{\"value\":10/* comment */}"));
         reader.ReadObject();
     }
 
     [TestMethod]
     public void Read_WithTrailingCommas_AllowTrailingCommasOption()
     {
-        using var reader = JsonReader.Create(
+        using var reader = new JsonReader(
             new StringReader("[1,2,3,]"),
             new JsonReaderOptions { AllowTrailingCommas = true });
         Assert.AreEqual(3, reader.ReadArray().Count);
@@ -38,7 +36,7 @@ public class OptionsTests
     [ExpectedException(typeof(JsonException))]
     public void Read_WithTrailingCommas_DefaultOptions_ThrowsException()
     {
-        using var reader = JsonReader.Create(new StringReader("[1,2,3,]"));
+        using var reader = new JsonReader(new StringReader("[1,2,3,]"));
         reader.ReadArray();
     }
 }

--- a/src/SergeiM.Json.Tests/JsonReaderTests/ReadArrayTests.cs
+++ b/src/SergeiM.Json.Tests/JsonReaderTests/ReadArrayTests.cs
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) [2025-2026] [Sergei Mukhin]
 // SPDX-License-Identifier: MIT
 
-using SergeiM.Json.IO;
-
 namespace SergeiM.Json.Tests.JsonReaderTests;
 
 [TestClass]
@@ -11,7 +9,7 @@ public class ReadArrayTests
     [TestMethod]
     public void ReadArray_ValidArray_ReturnsJsonArray()
     {
-        using var reader = JsonReader.Create(new StringReader("[10,20,30]"));
+        using var reader = new JsonReader(new StringReader("[10,20,30]"));
         var arr = reader.ReadArray();
         Assert.IsNotNull(arr);
         Assert.AreEqual(3, arr.Count);
@@ -23,7 +21,7 @@ public class ReadArrayTests
     [TestMethod]
     public void ReadArray_EmptyArray_ReturnsEmptyJsonArray()
     {
-        using var reader = JsonReader.Create(new StringReader("[]"));
+        using var reader = new JsonReader(new StringReader("[]"));
         var arr = reader.ReadArray();
         Assert.IsNotNull(arr);
         Assert.AreEqual(0, arr.Count);
@@ -32,7 +30,7 @@ public class ReadArrayTests
     [TestMethod]
     public void ReadArray_NestedArray_ReturnsNestedStructure()
     {
-        using var reader = JsonReader.Create(new StringReader("[[1,2],[3,4]]"));
+        using var reader = new JsonReader(new StringReader("[[1,2],[3,4]]"));
         var arr = reader.ReadArray();
         Assert.AreEqual(2, arr.Count);
         var first = arr.GetJsonArray(0);
@@ -44,7 +42,7 @@ public class ReadArrayTests
     [ExpectedException(typeof(JsonException))]
     public void ReadArray_NotAnArray_ThrowsJsonException()
     {
-        using var reader = JsonReader.Create(new StringReader("{\"key\":\"value\"}"));
+        using var reader = new JsonReader(new StringReader("{\"key\":\"value\"}"));
         reader.ReadArray();
     }
 }

--- a/src/SergeiM.Json.Tests/JsonReaderTests/ReadObjectTests.cs
+++ b/src/SergeiM.Json.Tests/JsonReaderTests/ReadObjectTests.cs
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) [2025-2026] [Sergei Mukhin]
 // SPDX-License-Identifier: MIT
 
-using SergeiM.Json.IO;
-
 namespace SergeiM.Json.Tests.JsonReaderTests;
 
 [TestClass]
@@ -11,7 +9,7 @@ public class ReadObjectTests
     [TestMethod]
     public void ReadObject_ValidObject_ReturnsJsonObject()
     {
-        using var reader = JsonReader.Create(new StringReader("{\"x\":10,\"y\":20}"));
+        using var reader = new JsonReader(new StringReader("{\"x\":10,\"y\":20}"));
         var obj = reader.ReadObject();
         Assert.IsNotNull(obj);
         Assert.AreEqual(10, obj.GetInt("x"));
@@ -21,7 +19,7 @@ public class ReadObjectTests
     [TestMethod]
     public void ReadObject_EmptyObject_ReturnsEmptyJsonObject()
     {
-        using var reader = JsonReader.Create(new StringReader("{}"));
+        using var reader = new JsonReader(new StringReader("{}"));
         var obj = reader.ReadObject();
         Assert.IsNotNull(obj);
         Assert.AreEqual(0, obj.Count);
@@ -30,7 +28,7 @@ public class ReadObjectTests
     [TestMethod]
     public void ReadObject_NestedObject_ReturnsNestedStructure()
     {
-        using var reader = JsonReader.Create(new StringReader("{\"outer\":{\"inner\":\"value\"}}"));
+        using var reader = new JsonReader(new StringReader("{\"outer\":{\"inner\":\"value\"}}"));
         var inner = reader.ReadObject().GetJsonObject("outer");
         Assert.IsNotNull(inner);
         Assert.AreEqual("value", inner!.GetString("inner"));
@@ -40,7 +38,7 @@ public class ReadObjectTests
     [ExpectedException(typeof(JsonException))]
     public void ReadObject_NotAnObject_ThrowsJsonException()
     {
-        using var reader = JsonReader.Create(new StringReader("[1,2,3]"));
+        using var reader = new JsonReader(new StringReader("[1,2,3]"));
         reader.ReadObject();
     }
 }

--- a/src/SergeiM.Json.Tests/JsonReaderTests/SpecialValuesTests.cs
+++ b/src/SergeiM.Json.Tests/JsonReaderTests/SpecialValuesTests.cs
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) [2025-2026] [Sergei Mukhin]
 // SPDX-License-Identifier: MIT
 
-using SergeiM.Json.IO;
-
 namespace SergeiM.Json.Tests.JsonReaderTests;
 
 [TestClass]
@@ -11,49 +9,49 @@ public class SpecialValuesTests
     [TestMethod]
     public void Read_EmptyString_ReturnsEmptyJsonString()
     {
-        using var reader = JsonReader.Create(new StringReader("\"\""));
+        using var reader = new JsonReader(new StringReader("\"\""));
         Assert.AreEqual("", ((JsonString)reader.Read()).Value);
     }
 
     [TestMethod]
     public void Read_EscapedCharacters_ParsesCorrectly()
     {
-        using var reader = JsonReader.Create(new StringReader("\"Hello\\nWorld\\t!\""));
+        using var reader = new JsonReader(new StringReader("\"Hello\\nWorld\\t!\""));
         Assert.AreEqual("Hello\nWorld\t!", ((JsonString)reader.Read()).Value);
     }
 
     [TestMethod]
     public void Read_UnicodeEscape_ParsesCorrectly()
     {
-        using var reader = JsonReader.Create(new StringReader("\"\\u0048\\u0065\\u006C\\u006C\\u006F\""));
+        using var reader = new JsonReader(new StringReader("\"\\u0048\\u0065\\u006C\\u006C\\u006F\""));
         Assert.AreEqual("Hello", ((JsonString)reader.Read()).Value);
     }
 
     [TestMethod]
     public void Read_LargeNumber_ParsesCorrectly()
     {
-        using var reader = JsonReader.Create(new StringReader("9999999999"));
+        using var reader = new JsonReader(new StringReader("9999999999"));
         Assert.AreEqual(9999999999L, ((JsonNumber)reader.Read()).LongValue());
     }
 
     [TestMethod]
     public void Read_DecimalNumber_ParsesCorrectly()
     {
-        using var reader = JsonReader.Create(new StringReader("3.14159"));
+        using var reader = new JsonReader(new StringReader("3.14159"));
         Assert.AreEqual(3.14159, ((JsonNumber)reader.Read()).DoubleValue(), 0.00001);
     }
 
     [TestMethod]
     public void Read_NegativeNumber_ParsesCorrectly()
     {
-        using var reader = JsonReader.Create(new StringReader("-42"));
+        using var reader = new JsonReader(new StringReader("-42"));
         Assert.AreEqual(-42, ((JsonNumber)reader.Read()).IntValue());
     }
 
     [TestMethod]
     public void Read_ScientificNotation_ParsesCorrectly()
     {
-        using var reader = JsonReader.Create(new StringReader("1.23e10"));
+        using var reader = new JsonReader(new StringReader("1.23e10"));
         Assert.AreEqual(1.23e10, ((JsonNumber)reader.Read()).DoubleValue(), 0.01);
     }
 }

--- a/src/SergeiM.Json.Tests/JsonReaderTests/StreamReadTests.cs
+++ b/src/SergeiM.Json.Tests/JsonReaderTests/StreamReadTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 using System.Text;
-using SergeiM.Json.IO;
 
 namespace SergeiM.Json.Tests.JsonReaderTests;
 
@@ -13,7 +12,7 @@ public class StreamReadTests
     public void Read_FromStream_ReturnsJsonValue()
     {
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes("{\"test\":123}"));
-        using var reader = JsonReader.Create(stream);
+        using var reader = new JsonReader(stream);
         var value = reader.Read();
         Assert.IsNotNull(value);
         var obj = value.AsJsonObject();
@@ -24,7 +23,7 @@ public class StreamReadTests
     public void ReadObject_FromStream_ReturnsJsonObject()
     {
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes("{\"value\":456}"));
-        using var reader = JsonReader.Create(stream);
+        using var reader = new JsonReader(stream);
         Assert.AreEqual(456, reader.ReadObject().GetInt("value"));
     }
 
@@ -32,7 +31,7 @@ public class StreamReadTests
     public void ReadArray_FromStream_ReturnsJsonArray()
     {
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes("[7,8,9]"));
-        using var reader = JsonReader.Create(stream);
+        using var reader = new JsonReader(stream);
         var arr = reader.ReadArray();
         Assert.AreEqual(3, arr.Count);
         Assert.AreEqual(7, arr.GetInt(0));

--- a/src/SergeiM.Json.Tests/JsonWriterTests/BasicWriteTests.cs
+++ b/src/SergeiM.Json.Tests/JsonWriterTests/BasicWriteTests.cs
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) [2025-2026] [Sergei Mukhin]
 // SPDX-License-Identifier: MIT
 
-using SergeiM.Json.IO;
-
 namespace SergeiM.Json.Tests.JsonWriterTests;
 
 [TestClass]
@@ -12,7 +10,7 @@ public class BasicWriteTests
     public void Write_SimpleObject_WritesCorrectJson()
     {
         using var writer = new StringWriter();
-        using var jsonWriter = JsonWriter.Create(writer);
+        using var jsonWriter = new JsonWriter(writer);
         jsonWriter.Write(new JsonObjectBuilder()
             .Add("name", "Alice")
             .Add("age", 30)
@@ -26,7 +24,7 @@ public class BasicWriteTests
     public void Write_SimpleArray_WritesCorrectJson()
     {
         using var writer = new StringWriter();
-        using var jsonWriter = JsonWriter.Create(writer);
+        using var jsonWriter = new JsonWriter(writer);
         jsonWriter.Write(new JsonArrayBuilder()
             .Add(1)
             .Add(2)
@@ -40,7 +38,7 @@ public class BasicWriteTests
     public void Write_String_WritesQuotedString()
     {
         using var writer = new StringWriter();
-        using var jsonWriter = JsonWriter.Create(writer);
+        using var jsonWriter = new JsonWriter(writer);
         jsonWriter.Write(new JsonString("hello"));
         var json = writer.ToString();
         Assert.AreEqual("\"hello\"", json);
@@ -50,7 +48,7 @@ public class BasicWriteTests
     public void Write_Number_WritesNumber()
     {
         using var writer = new StringWriter();
-        using var jsonWriter = JsonWriter.Create(writer);
+        using var jsonWriter = new JsonWriter(writer);
         jsonWriter.Write(new JsonNumber(42));
         var json = writer.ToString();
         Assert.AreEqual("42", json);
@@ -60,7 +58,7 @@ public class BasicWriteTests
     public void Write_Boolean_WritesBoolean()
     {
         using var writer = new StringWriter();
-        using var jsonWriter = JsonWriter.Create(writer);
+        using var jsonWriter = new JsonWriter(writer);
         jsonWriter.Write(JsonValue.True);
         var json = writer.ToString();
         Assert.AreEqual("true", json);
@@ -70,7 +68,7 @@ public class BasicWriteTests
     public void Write_Null_WritesNull()
     {
         using var writer = new StringWriter();
-        using var jsonWriter = JsonWriter.Create(writer);
+        using var jsonWriter = new JsonWriter(writer);
         jsonWriter.Write(JsonValue.Null);
         var json = writer.ToString();
         Assert.AreEqual("null", json);
@@ -80,7 +78,7 @@ public class BasicWriteTests
     public void Write_CyrillicString_WritesCorrectJson()
     {
         using var writer = new StringWriter();
-        using var jsonWriter = JsonWriter.Create(writer, JsonWriterOptions.UnicodeUnescaped);
+        using var jsonWriter = new JsonWriter(writer, JsonWriterOptions.UnicodeUnescaped);
         jsonWriter.Write(new JsonString("Привет"));
         var json = writer.ToString();
         Assert.AreEqual("\"Привет\"", json);
@@ -90,7 +88,7 @@ public class BasicWriteTests
     public void Write_CyrillicString_DefaultEncoder_EscapesUnicode()
     {
         using var writer = new StringWriter();
-        using var jsonWriter = JsonWriter.Create(writer);
+        using var jsonWriter = new JsonWriter(writer);
         jsonWriter.Write(new JsonString("Привет"));
         var json = writer.ToString();
         Assert.AreEqual("\"\\u041F\\u0440\\u0438\\u0432\\u0435\\u0442\"", json);

--- a/src/SergeiM.Json.Tests/JsonWriterTests/ComplexStructureTests.cs
+++ b/src/SergeiM.Json.Tests/JsonWriterTests/ComplexStructureTests.cs
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) [2025-2026] [Sergei Mukhin]
 // SPDX-License-Identifier: MIT
 
-using SergeiM.Json.IO;
-
 namespace SergeiM.Json.Tests.JsonWriterTests;
 
 [TestClass]
@@ -23,7 +21,7 @@ public class ComplexStructureTests
                     .Add("555-5678")))
             .Build();
         using var writer = new StringWriter();
-        using var jsonWriter = JsonWriter.Create(writer);
+        using var jsonWriter = new JsonWriter(writer);
         jsonWriter.Write(json);
         var result = writer.ToString();
         Assert.IsTrue(result.Contains("\"person\":{"));
@@ -43,7 +41,7 @@ public class ComplexStructureTests
                 .Add("name", "Bob"))
             .Build();
         using var writer = new StringWriter();
-        using var jsonWriter = JsonWriter.Create(writer);
+        using var jsonWriter = new JsonWriter(writer);
         jsonWriter.Write(arr);
         var result = writer.ToString();
         Assert.IsTrue(result.Contains("{\"id\":1,\"name\":\"Alice\"}") ||

--- a/src/SergeiM.Json.Tests/JsonWriterTests/FormattingTests.cs
+++ b/src/SergeiM.Json.Tests/JsonWriterTests/FormattingTests.cs
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) [2025-2026] [Sergei Mukhin]
 // SPDX-License-Identifier: MIT
 
-using SergeiM.Json.IO;
-
 namespace SergeiM.Json.Tests.JsonWriterTests;
 
 [TestClass]
@@ -12,7 +10,7 @@ public class FormattingTests
     public void Write_WithIndent_WritesIndentedJson()
     {
         using var writer = new StringWriter();
-        using var jsonWriter = JsonWriter.Create(writer, JsonWriterOptions.PrettyPrint);
+        using var jsonWriter = new JsonWriter(writer, JsonWriterOptions.PrettyPrint);
         jsonWriter.Write(new JsonObjectBuilder()
             .Add("name", "Alice")
             .Add("age", 30)
@@ -26,7 +24,7 @@ public class FormattingTests
     public void Write_DefaultOptions_WritesCompactJson()
     {
         using var writer = new StringWriter();
-        using var jsonWriter = JsonWriter.Create(writer);
+        using var jsonWriter = new JsonWriter(writer);
         jsonWriter.Write(new JsonObjectBuilder()
             .Add("x", 1)
             .Add("y", 2)
@@ -39,7 +37,7 @@ public class FormattingTests
     public void Write_CustomIndent_UsesCustomIndentation()
     {
         using var writer = new StringWriter();
-        using var jsonWriter = JsonWriter.Create(writer, new JsonWriterOptions
+        using var jsonWriter = new JsonWriter(writer, new JsonWriterOptions
         {
             IndentOutput = true,
             IndentString = "\t"

--- a/src/SergeiM.Json.Tests/JsonWriterTests/NumberFormattingTests.cs
+++ b/src/SergeiM.Json.Tests/JsonWriterTests/NumberFormattingTests.cs
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) [2025-2026] [Sergei Mukhin]
 // SPDX-License-Identifier: MIT
 
-using SergeiM.Json.IO;
-
 namespace SergeiM.Json.Tests.JsonWriterTests;
 
 [TestClass]
@@ -12,7 +10,7 @@ public class NumberFormattingTests
     public void Write_Integer_WritesInteger()
     {
         using var writer = new StringWriter();
-        using var jsonWriter = JsonWriter.Create(writer);
+        using var jsonWriter = new JsonWriter(writer);
         jsonWriter.Write(new JsonNumber(42));
         var json = writer.ToString();
         Assert.AreEqual("42", json);
@@ -22,7 +20,7 @@ public class NumberFormattingTests
     public void Write_Decimal_WritesDecimal()
     {
         using var writer = new StringWriter();
-        using var jsonWriter = JsonWriter.Create(writer);
+        using var jsonWriter = new JsonWriter(writer);
         jsonWriter.Write(new JsonNumber(3.14m));
         var json = writer.ToString();
         Assert.IsTrue(json.StartsWith("3.14"));
@@ -32,7 +30,7 @@ public class NumberFormattingTests
     public void Write_NegativeNumber_WritesNegativeNumber()
     {
         using var writer = new StringWriter();
-        using var jsonWriter = JsonWriter.Create(writer);
+        using var jsonWriter = new JsonWriter(writer);
         jsonWriter.Write(new JsonNumber(-42));
         var json = writer.ToString();
         Assert.AreEqual("-42", json);
@@ -42,7 +40,7 @@ public class NumberFormattingTests
     public void Write_LargeNumber_WritesLargeNumber()
     {
         using var writer = new StringWriter();
-        using var jsonWriter = JsonWriter.Create(writer);
+        using var jsonWriter = new JsonWriter(writer);
         jsonWriter.Write(new JsonNumber(9999999999L));
         var json = writer.ToString();
         Assert.AreEqual("9999999999", json);

--- a/src/SergeiM.Json.Tests/JsonWriterTests/RoundTripTests.cs
+++ b/src/SergeiM.Json.Tests/JsonWriterTests/RoundTripTests.cs
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) [2025-2026] [Sergei Mukhin]
 // SPDX-License-Identifier: MIT
 
-using SergeiM.Json.IO;
-
 namespace SergeiM.Json.Tests.JsonWriterTests;
 
 [TestClass]
@@ -18,10 +16,10 @@ public class RoundTripTests
             .AddNull("null")
             .Build();
         using var writer = new StringWriter();
-        using var jsonWriter = JsonWriter.Create(writer);
+        using var jsonWriter = new JsonWriter(writer);
         jsonWriter.Write(original);
         var json = writer.ToString();
-        using var reader = JsonReader.Create(new StringReader(json));
+        using var reader = new JsonReader(new StringReader(json));
         var parsed = reader.ReadObject();
         Assert.AreEqual("value", parsed.GetString("string"));
         Assert.AreEqual(42, parsed.GetInt("number"));
@@ -39,10 +37,10 @@ public class RoundTripTests
             .AddNull()
             .Build();
         using var writer = new StringWriter();
-        using var jsonWriter = JsonWriter.Create(writer);
+        using var jsonWriter = new JsonWriter(writer);
         jsonWriter.Write(original);
         var json = writer.ToString();
-        using var reader = JsonReader.Create(new StringReader(json));
+        using var reader = new JsonReader(new StringReader(json));
         var parsed = reader.ReadArray();
         Assert.AreEqual("text", parsed.GetString(0));
         Assert.AreEqual(123, parsed.GetInt(1));
@@ -61,10 +59,10 @@ public class RoundTripTests
                     .Add(3)))
             .Build();
         using var writer = new StringWriter();
-        using var jsonWriter = JsonWriter.Create(writer);
+        using var jsonWriter = new JsonWriter(writer);
         jsonWriter.Write(original);
         var json = writer.ToString();
-        using var reader = JsonReader.Create(new StringReader(json));
+        using var reader = new JsonReader(new StringReader(json));
         var parsed = reader.ReadObject();
         var nested = parsed.GetJsonObject("nested");
         var array = nested!.GetJsonArray("array");

--- a/src/SergeiM.Json.Tests/JsonWriterTests/SpecialCharacterTests.cs
+++ b/src/SergeiM.Json.Tests/JsonWriterTests/SpecialCharacterTests.cs
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) [2025-2026] [Sergei Mukhin]
 // SPDX-License-Identifier: MIT
 
-using SergeiM.Json.IO;
-
 namespace SergeiM.Json.Tests.JsonWriterTests;
 
 [TestClass]
@@ -13,7 +11,7 @@ public class SpecialCharacterTests
     {
 
         using var writer = new StringWriter();
-        using var jsonWriter = JsonWriter.Create(writer);
+        using var jsonWriter = new JsonWriter(writer);
         jsonWriter.Write(new JsonString("She said \"hello\""));
         var json = writer.ToString();
         Assert.IsTrue(json.Contains("She said"));
@@ -24,7 +22,7 @@ public class SpecialCharacterTests
     public void Write_StringWithBackslash_EscapesBackslash()
     {
         using var writer = new StringWriter();
-        using var jsonWriter = JsonWriter.Create(writer);
+        using var jsonWriter = new JsonWriter(writer);
         jsonWriter.Write(new JsonString("C:\\path\\to\\file"));
         var json = writer.ToString();
         Assert.IsTrue(json.Contains("\\\\"));
@@ -34,7 +32,7 @@ public class SpecialCharacterTests
     public void Write_StringWithNewline_EscapesNewline()
     {
         using var writer = new StringWriter();
-        using var jsonWriter = JsonWriter.Create(writer);
+        using var jsonWriter = new JsonWriter(writer);
         jsonWriter.Write(new JsonString("Line1\nLine2"));
         var json = writer.ToString();
         Assert.IsTrue(json.Contains("\\n"));
@@ -44,7 +42,7 @@ public class SpecialCharacterTests
     public void Write_EmptyString_WritesEmptyQuotes()
     {
         using var writer = new StringWriter();
-        using var jsonWriter = JsonWriter.Create(writer);
+        using var jsonWriter = new JsonWriter(writer);
         jsonWriter.Write(new JsonString(""));
         var json = writer.ToString();
         Assert.AreEqual("\"\"", json);

--- a/src/SergeiM.Json.Tests/JsonWriterTests/StreamWriteTests.cs
+++ b/src/SergeiM.Json.Tests/JsonWriterTests/StreamWriteTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 using System.Text;
-using SergeiM.Json.IO;
 
 namespace SergeiM.Json.Tests.JsonWriterTests;
 
@@ -13,7 +12,7 @@ public class StreamWriteTests
     public void Write_ToStream_WritesCorrectBytes()
     {
         using var stream = new MemoryStream();
-        using var jsonWriter = JsonWriter.Create(stream);
+        using var jsonWriter = new JsonWriter(stream);
         jsonWriter.Write(new JsonObjectBuilder()
             .Add("test", 123)
             .Build());
@@ -26,7 +25,7 @@ public class StreamWriteTests
     public void WriteObject_ToStream_WritesCorrectBytes()
     {
         using var stream = new MemoryStream();
-        using var jsonWriter = JsonWriter.Create(stream);
+        using var jsonWriter = new JsonWriter(stream);
         jsonWriter.WriteObject(new JsonObjectBuilder()
             .Add("value", 456)
             .Build());
@@ -39,7 +38,7 @@ public class StreamWriteTests
     public void WriteArray_ToStream_WritesCorrectBytes()
     {
         using var stream = new MemoryStream();
-        using var jsonWriter = JsonWriter.Create(stream);
+        using var jsonWriter = new JsonWriter(stream);
         jsonWriter.WriteArray(new JsonArrayBuilder()
             .Add(7)
             .Add(8)

--- a/src/SergeiM.Json.Tests/JsonWriterTests/WriteArrayTests.cs
+++ b/src/SergeiM.Json.Tests/JsonWriterTests/WriteArrayTests.cs
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) [2025-2026] [Sergei Mukhin]
 // SPDX-License-Identifier: MIT
 
-using SergeiM.Json.IO;
-
 namespace SergeiM.Json.Tests.JsonWriterTests;
 
 [TestClass]
@@ -12,7 +10,7 @@ public class WriteArrayTests
     public void WriteArray_EmptyArray_WritesEmptyBrackets()
     {
         using var writer = new StringWriter();
-        using var jsonWriter = JsonWriter.Create(writer);
+        using var jsonWriter = new JsonWriter(writer);
         jsonWriter.WriteArray(JsonArray.Empty);
         var json = writer.ToString();
         Assert.AreEqual("[]", json);
@@ -22,7 +20,7 @@ public class WriteArrayTests
     public void WriteArray_WithElements_WritesAllElements()
     {
         using var writer = new StringWriter();
-        using var jsonWriter = JsonWriter.Create(writer);
+        using var jsonWriter = new JsonWriter(writer);
         jsonWriter.WriteArray(new JsonArrayBuilder()
             .Add(1)
             .Add(2)
@@ -42,7 +40,7 @@ public class WriteArrayTests
                 .Build())
             .Build();
         using var writer = new StringWriter();
-        using var jsonWriter = JsonWriter.Create(writer);
+        using var jsonWriter = new JsonWriter(writer);
         jsonWriter.WriteArray(arr);
         var json = writer.ToString();
         Assert.AreEqual("[[1,2]]", json);

--- a/src/SergeiM.Json.Tests/JsonWriterTests/WriteObjectTests.cs
+++ b/src/SergeiM.Json.Tests/JsonWriterTests/WriteObjectTests.cs
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) [2025-2026] [Sergei Mukhin]
 // SPDX-License-Identifier: MIT
 
-using SergeiM.Json.IO;
-
 namespace SergeiM.Json.Tests.JsonWriterTests;
 
 [TestClass]
@@ -12,7 +10,7 @@ public class WriteObjectTests
     public void WriteObject_EmptyObject_WritesEmptyBraces()
     {
         using var writer = new StringWriter();
-        using var jsonWriter = JsonWriter.Create(writer);
+        using var jsonWriter = new JsonWriter(writer);
         jsonWriter.WriteObject(JsonObject.Empty);
         var json = writer.ToString();
         Assert.AreEqual("{}", json);
@@ -22,7 +20,7 @@ public class WriteObjectTests
     public void WriteObject_WithProperties_WritesAllProperties()
     {
         using var writer = new StringWriter();
-        using var jsonWriter = JsonWriter.Create(writer);
+        using var jsonWriter = new JsonWriter(writer);
         jsonWriter.WriteObject(new JsonObjectBuilder()
             .Add("x", 10)
             .Add("y", 20)
@@ -41,7 +39,7 @@ public class WriteObjectTests
                 .Build())
             .Build();
         using var writer = new StringWriter();
-        using var jsonWriter = JsonWriter.Create(writer);
+        using var jsonWriter = new JsonWriter(writer);
         jsonWriter.WriteObject(obj);
         var json = writer.ToString();
         Assert.IsTrue(json.Contains("\"outer\":{\"inner\":\"value\"}"));

--- a/src/SergeiM.Json/Extensions/JsonValueExtensions.cs
+++ b/src/SergeiM.Json/Extensions/JsonValueExtensions.cs
@@ -44,7 +44,7 @@ public static class JsonValueExtensions
         ArgumentNullException.ThrowIfNull(value);
         using var writer = new StringWriter();
         var options = indented ? JsonWriterOptions.PrettyPrint : JsonWriterOptions.Default;
-        using (var jsonWriter = JsonWriter.Create(writer, options))
+        using (var jsonWriter = new JsonWriter(writer, options))
         {
             jsonWriter.Write(value);
         }

--- a/src/SergeiM.Json/IO/JsonReader.cs
+++ b/src/SergeiM.Json/IO/JsonReader.cs
@@ -17,16 +17,13 @@ public sealed class JsonReader : IDisposable
     private readonly JsonReaderOptions _options;
     private bool _disposed;
 
-    private JsonReader(Stream stream, JsonReaderOptions options)
+    /// <summary>
+    /// Creates a JSON reader from a stream with default options.
+    /// </summary>
+    /// <param name="stream">The stream to read from.</param>
+    public JsonReader(Stream stream)
+        : this(stream, JsonReaderOptions.Default)
     {
-        _stream = stream ?? throw new ArgumentNullException(nameof(stream));
-        _options = options ?? JsonReaderOptions.Default;
-    }
-
-    private JsonReader(TextReader textReader, JsonReaderOptions options)
-    {
-        _textReader = textReader ?? throw new ArgumentNullException(nameof(textReader));
-        _options = options ?? JsonReaderOptions.Default;
     }
 
     /// <summary>
@@ -35,9 +32,19 @@ public sealed class JsonReader : IDisposable
     /// <param name="stream">The stream to read from.</param>
     /// <param name="options">Reader options. If null, default options are used.</param>
     /// <returns>A new JSON reader.</returns>
-    public static JsonReader Create(Stream stream, JsonReaderOptions? options = null)
+    public JsonReader(Stream stream, JsonReaderOptions options)
     {
-        return new JsonReader(stream, options ?? JsonReaderOptions.Default);
+        _stream = stream ?? throw new ArgumentNullException(nameof(stream));
+        _options = options ?? JsonReaderOptions.Default;
+    }
+
+    /// <summary>
+    /// Creates a JSON reader from a TextReader with default options.
+    /// </summary>
+    /// <param name="textReader">The text reader to read from.</param>
+    public JsonReader(TextReader textReader)
+        : this(textReader, JsonReaderOptions.Default)
+    {
     }
 
     /// <summary>
@@ -46,9 +53,10 @@ public sealed class JsonReader : IDisposable
     /// <param name="textReader">The text reader to read from.</param>
     /// <param name="options">Reader options. If null, default options are used.</param>
     /// <returns>A new JSON reader.</returns>
-    public static JsonReader Create(TextReader textReader, JsonReaderOptions? options = null)
+    public JsonReader(TextReader textReader, JsonReaderOptions options)
     {
-        return new JsonReader(textReader, options ?? JsonReaderOptions.Default);
+        _textReader = textReader ?? throw new ArgumentNullException(nameof(textReader));
+        _options = options ?? JsonReaderOptions.Default;
     }
 
     /// <summary>

--- a/src/SergeiM.Json/IO/JsonWriter.cs
+++ b/src/SergeiM.Json/IO/JsonWriter.cs
@@ -17,16 +17,13 @@ public sealed class JsonWriter : IDisposable
     private Utf8JsonWriter? _utf8JsonWriter;
     private bool _disposed;
 
-    private JsonWriter(Stream stream, JsonWriterOptions options)
+    /// <summary>
+    /// Creates a JSON writer that writes to a stream with default options.
+    /// </summary>
+    /// <param name="stream">The stream to write to.</param>
+    public JsonWriter(Stream stream)
+        : this(stream, JsonWriterOptions.Default)
     {
-        _stream = stream ?? throw new ArgumentNullException(nameof(stream));
-        _options = options ?? JsonWriterOptions.Default;
-    }
-
-    private JsonWriter(TextWriter textWriter, JsonWriterOptions options)
-    {
-        _textWriter = textWriter ?? throw new ArgumentNullException(nameof(textWriter));
-        _options = options ?? JsonWriterOptions.Default;
     }
 
     /// <summary>
@@ -35,9 +32,19 @@ public sealed class JsonWriter : IDisposable
     /// <param name="stream">The stream to write to.</param>
     /// <param name="options">Writer options. If null, default options are used.</param>
     /// <returns>A new JSON writer.</returns>
-    public static JsonWriter Create(Stream stream, JsonWriterOptions? options = null)
+    public JsonWriter(Stream stream, JsonWriterOptions options)
     {
-        return new JsonWriter(stream, options ?? JsonWriterOptions.Default);
+        _stream = stream ?? throw new ArgumentNullException(nameof(stream));
+        _options = options ?? JsonWriterOptions.Default;
+    }
+
+    /// <summary>
+    /// Creates a JSON writer that writes to a TextWriter with default options.
+    /// </summary>
+    /// <param name="textWriter">The text writer to write to.</param>
+    public JsonWriter(TextWriter textWriter)
+        : this(textWriter, JsonWriterOptions.Default)
+    {
     }
 
     /// <summary>
@@ -46,9 +53,10 @@ public sealed class JsonWriter : IDisposable
     /// <param name="textWriter">The text writer to write to.</param>
     /// <param name="options">Writer options. If null, default options are used.</param>
     /// <returns>A new JSON writer.</returns>
-    public static JsonWriter Create(TextWriter textWriter, JsonWriterOptions? options = null)
+    public JsonWriter(TextWriter textWriter, JsonWriterOptions options)
     {
-        return new JsonWriter(textWriter, options ?? JsonWriterOptions.Default);
+        _textWriter = textWriter ?? throw new ArgumentNullException(nameof(textWriter));
+        _options = options ?? JsonWriterOptions.Default;
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #1 

This pull request updates all usage of the static factory method `JsonReader.Create` to direct constructor calls using `new JsonReader(...)` across the codebase, including documentation and tests. This change simplifies and unifies object instantiation for `JsonReader`, and removes now-unnecessary `using` directives. The most important changes are grouped below:

**API Usage Update:**

* Replaced all instances of `JsonReader.Create(...)` with direct `new JsonReader(...)` constructor calls in test files, ensuring consistency and reflecting the preferred instantiation method. [[1]](diffhunk://#diff-479b5649e93f609a71f25b725efd2eecc510dc0969b86a3b9257913bcb530d87L14-R12) [[2]](diffhunk://#diff-479b5649e93f609a71f25b725efd2eecc510dc0969b86a3b9257913bcb530d87L26-R24) [[3]](diffhunk://#diff-479b5649e93f609a71f25b725efd2eecc510dc0969b86a3b9257913bcb530d87L40-R38) [[4]](diffhunk://#diff-479b5649e93f609a71f25b725efd2eecc510dc0969b86a3b9257913bcb530d87L50-R48) [[5]](diffhunk://#diff-479b5649e93f609a71f25b725efd2eecc510dc0969b86a3b9257913bcb530d87L60-R58) [[6]](diffhunk://#diff-479b5649e93f609a71f25b725efd2eecc510dc0969b86a3b9257913bcb530d87L70-R68) [[7]](diffhunk://#diff-0cbab5aebdcba34ee1946807b85ced36be866b3d02102accfad69c2cc5b32536L25-R23) [[8]](diffhunk://#diff-0cbab5aebdcba34ee1946807b85ced36be866b3d02102accfad69c2cc5b32536L48-R46) [[9]](diffhunk://#diff-fce35d20fa4c838fa592f496e3d8d9c71699927148a7664702346ad2b2fd5d0cL15-R37) [[10]](diffhunk://#diff-abe0a8ec4d2995a1b5347540bd8aba7d350da0d03d5fb08bc2e1314869186152L14-R12) [[11]](diffhunk://#diff-abe0a8ec4d2995a1b5347540bd8aba7d350da0d03d5fb08bc2e1314869186152L24-R29) [[12]](diffhunk://#diff-abe0a8ec4d2995a1b5347540bd8aba7d350da0d03d5fb08bc2e1314869186152L41-R39) [[13]](diffhunk://#diff-8d0754d682b426cef2decd1eef5a9a7dff8da5a950b328dbff2f1bd045c4d039L14-R12) [[14]](diffhunk://#diff-8d0754d682b426cef2decd1eef5a9a7dff8da5a950b328dbff2f1bd045c4d039L26-R24) [[15]](diffhunk://#diff-8d0754d682b426cef2decd1eef5a9a7dff8da5a950b328dbff2f1bd045c4d039L35-R33) [[16]](diffhunk://#diff-8d0754d682b426cef2decd1eef5a9a7dff8da5a950b328dbff2f1bd045c4d039L47-R45) [[17]](diffhunk://#diff-aa3223ef85b0c340c3ee4ba192cd7d5bd18ce10d0be309247d4f11a7c45a3ddeL14-R12) [[18]](diffhunk://#diff-aa3223ef85b0c340c3ee4ba192cd7d5bd18ce10d0be309247d4f11a7c45a3ddeL24-R22) [[19]](diffhunk://#diff-aa3223ef85b0c340c3ee4ba192cd7d5bd18ce10d0be309247d4f11a7c45a3ddeL33-R31) [[20]](diffhunk://#diff-aa3223ef85b0c340c3ee4ba192cd7d5bd18ce10d0be309247d4f11a7c45a3ddeL43-R41)

* Updated the `README.md` documentation to use `new JsonReader(...)` and `new JsonWriter(...)` instead of their respective `.Create` methods, providing clearer usage examples for users.

**Code Cleanup:**

* Removed unnecessary `using SergeiM.Json.IO;` directives from all test files, as direct constructor usage makes these imports redundant. [[1]](diffhunk://#diff-479b5649e93f609a71f25b725efd2eecc510dc0969b86a3b9257913bcb530d87L4-L5) [[2]](diffhunk://#diff-0cbab5aebdcba34ee1946807b85ced36be866b3d02102accfad69c2cc5b32536L4-L5) [[3]](diffhunk://#diff-fce35d20fa4c838fa592f496e3d8d9c71699927148a7664702346ad2b2fd5d0cL4-L5) [[4]](diffhunk://#diff-abe0a8ec4d2995a1b5347540bd8aba7d350da0d03d5fb08bc2e1314869186152L4-L5) [[5]](diffhunk://#diff-8d0754d682b426cef2decd1eef5a9a7dff8da5a950b328dbff2f1bd045c4d039L4-L5) [[6]](diffhunk://#diff-aa3223ef85b0c340c3ee4ba192cd7d5bd18ce10d0be309247d4f11a7c45a3ddeL4-L5) [[7]](diffhunk://#diff-894473d2eb2ade99962faace7aad4bbb734ff0cd25e29f21a7c0fa81c2113280L4-L5)

* Removed a redundant global using of `SergeiM.Json` in `GlobalUsings.cs`, further cleaning up the test setup.