### PR TITLE
chore(#4): switch to NuGet trusted publishing (OIDC, keyless)

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -16,6 +16,8 @@ name: Publish to NuGet
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -36,6 +38,11 @@ jobs:
       - name: Pack
         run: dotnet pack --configuration Release --no-build --output ./nupkg
         working-directory: ./src
+      - name: NuGet login (OIDC → temp API key)
+        uses: NuGet/login@v1
+        id: login
+        with:
+          user: ${{ vars.NUGET_USER }}
       - name: Publish to NuGet
-        run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+        run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
         working-directory: ./src


### PR DESCRIPTION
Close #4 

This pull request updates the NuGet publishing workflow to improve security by switching from using a static API key to using OpenID Connect (OIDC) authentication for publishing packages. The workflow now logs in to NuGet using OIDC to obtain a temporary API key, which is then used for publishing.

**Security and authentication improvements:**

* Added `id-token: write` permission to the `publish` job in `.github/workflows/publish-nuget.yml` to enable OIDC authentication.
* Introduced a new step to log in to NuGet using the `NuGet/login@v1` action with OIDC, storing the temporary API key in the workflow output.
* Updated the publish step to use the OIDC-generated API key instead of a static secret, enhancing security and reducing secret management overhead.